### PR TITLE
Removed GUILD_ID from env config

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,7 +1,6 @@
 CLIENT_ID="your_client_id_here"
-GUILD_ID="your_guild_id_here"
 DISCORD_TOKEN="your_discord_token_here"
 
-# OPTIONAL FOR LOGGING WITH LOGGLY
+# OPTIONAL FOR LOGGING WITH LOGTAIL (BETTER STACK)
 LOGTAIL_SOURCE_TOKEN="your_logtail_source_token_here"
 LOGTAIL_INGESTING_HOST="your_logtail_ingesting_host"

--- a/bot/src/types/environment.d.ts
+++ b/bot/src/types/environment.d.ts
@@ -1,7 +1,8 @@
 declare namespace NodeJS {
     interface ProcessEnv {
         CLIENT_ID: string;
-        GUILD_ID: string;
         DISCORD_TOKEN: string;
+        LOGTAIL_SOURCE_TOKEN?: string;
+        LOGTAIL_INGESTING_HOST?: string;
     }
 }


### PR DESCRIPTION
Unnecessary after deploying commands went global.

Follow up to #66 and ideally should NOT build in Vercel.

```bash
if [ "$VERCEL_ENV" == "production" ] && git diff HEAD^ HEAD --quiet -- ./web; then exit 1; else exit 0; fi
```