### PR TITLE
fix: make bot health readiness-aware

### DIFF
--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -92,17 +92,17 @@ jobs:
                   IMAGE_TAG: powercord-bot-validate:${{ github.sha }}
               run: |
                   docker run -d --name bot-validate -p 3000:3000 "${IMAGE_TAG}"
-                  echo "Waiting for health endpoint..."
+                  echo "Waiting for liveness endpoint..."
                   for attempt in {1..30}; do
-                    echo "Health check attempt ${attempt}/30"
-                    if curl -sf http://localhost:3000/health > /dev/null; then
-                      echo "Health check passed"
+                    echo "Liveness check attempt ${attempt}/30"
+                    if curl -sf http://localhost:3000/live > /dev/null; then
+                      echo "Liveness check passed"
                       break
                     fi
                     sleep 2
                   done
-                  if ! curl -sf http://localhost:3000/health > /dev/null; then
-                    echo "Container did not become healthy in time" >&2
+                  if ! curl -sf http://localhost:3000/live > /dev/null; then
+                    echo "Container did not become live in time" >&2
                     docker logs --tail 200 bot-validate || true
                     exit 1
                   fi

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ blobs from S3 into memory and answers Discord autocomplete locally. If the cache
 is not ready or a refresh fails before any cache is loaded, the bot falls back to
 the public HTTP autocomplete API configured by `API_BASE_URL`.
 
+The bot exposes `GET /live` for process liveness and `GET /health` for readiness.
+Readiness returns `200` only while the Discord client is connected and ready;
+otherwise it returns `503`. Better Stack heartbeats follow the same readiness
+signal so startup or gateway failures are not reported as healthy.
+
 ### Project
 
 In the root directory of the project enter the following commands. This will install all dependencies and begin the dev instance.

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -6,6 +6,7 @@ import { deployCommands } from './deploy-commands';
 import { errorLogFields } from './logging/fields';
 import logger from './logging/logger';
 import { Command } from './types/command';
+import { setDiscordClient } from './utils/botState';
 import { config } from './utils/config';
 import './utils/health';
 import { startHeartbeat } from './utils/heartbeat';
@@ -44,6 +45,7 @@ async function initializeBot() {
     const client = new Client({
         intents: [GatewayIntentBits.Guilds],
     });
+    setDiscordClient(client);
 
     client.commands = new Collection<string, Command>();
 

--- a/bot/src/utils/botState.ts
+++ b/bot/src/utils/botState.ts
@@ -1,0 +1,13 @@
+import type { Client } from 'discord.js';
+
+type DiscordClientState = Pick<Client, 'isReady'>;
+
+let discordClient: DiscordClientState | undefined;
+
+export function setDiscordClient(client: DiscordClientState): void {
+    discordClient = client;
+}
+
+export function isBotReady(): boolean {
+    return discordClient?.isReady() ?? false;
+}

--- a/bot/src/utils/health.ts
+++ b/bot/src/utils/health.ts
@@ -1,11 +1,21 @@
 import express from 'express';
 import logger from '../logging/logger';
+import { isBotReady } from './botState';
 
 const app = express();
 const port = 3000;
 
-app.get('/health', (req, res) => {
+app.get('/live', (_req, res) => {
     res.send({ status: 'ok' });
+});
+
+app.get('/health', (_req, res) => {
+    if (isBotReady()) {
+        res.send({ status: 'ok' });
+        return;
+    }
+
+    res.status(503).send({ status: 'not_ready' });
 });
 
 app.listen(port, () => {

--- a/bot/src/utils/heartbeat.ts
+++ b/bot/src/utils/heartbeat.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { errorLogFields } from '../logging/fields';
 import logger from '../logging/logger';
+import { isBotReady } from './botState';
 import { config } from './config';
 
 const HEARTBEAT_INTERVAL = 60000; // 60 seconds
@@ -26,6 +27,14 @@ export function startHeartbeat() {
 }
 
 async function sendHeartbeat() {
+    if (!isBotReady()) {
+        logger.debug(
+            { event: 'heartbeat.skipped', reason: 'bot_not_ready' },
+            'skipping BetterStack heartbeat while bot is not ready',
+        );
+        return;
+    }
+
     try {
         await axios.get(config.BETTERSTACK_HEARTBEAT_URL!, { timeout: 5000 });
     } catch (error) {

--- a/bot/test/utils/botState.test.ts
+++ b/bot/test/utils/botState.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isBotReady, setDiscordClient } from '../../src/utils/botState';
+
+describe('botState', () => {
+    it('is not ready before a Discord client is registered', () => {
+        expect(isBotReady()).toBe(false);
+    });
+
+    it('reflects the Discord client readiness state', () => {
+        const isReady = vi.fn().mockReturnValue(false);
+        setDiscordClient({ isReady });
+
+        expect(isBotReady()).toBe(false);
+
+        isReady.mockReturnValue(true);
+        expect(isBotReady()).toBe(true);
+    });
+});

--- a/bot/test/utils/health.test.ts
+++ b/bot/test/utils/health.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import logger from '../../src/logging/logger';
+import { isBotReady } from '../../src/utils/botState';
 
 vi.mock('express', () => ({
     default: vi.fn(() => ({
@@ -16,6 +17,10 @@ vi.mock('../../src/logging/logger', () => ({
     default: {
         info: vi.fn(),
     },
+}));
+
+vi.mock('../../src/utils/botState', () => ({
+    isBotReady: vi.fn(),
 }));
 
 describe('health', () => {
@@ -36,6 +41,25 @@ describe('health', () => {
         await import('../../src/utils/health');
     });
 
+    beforeEach(() => {
+        vi.mocked(isBotReady).mockReturnValue(false);
+    });
+
+    it('registers GET /live route', () => {
+        expect(mockApp.get).toHaveBeenCalledWith('/live', expect.any(Function));
+    });
+
+    it('GET /live handler always reports liveness', () => {
+        const handler = (mockApp.get.mock.calls as any[]).find(
+            ([path]) => path === '/live',
+        )?.[1];
+        const res = { send: vi.fn() };
+
+        handler({}, res);
+
+        expect(res.send).toHaveBeenCalledWith({ status: 'ok' });
+    });
+
     it('registers GET /health route', () => {
         expect(mockApp.get).toHaveBeenCalledWith(
             '/health',
@@ -43,13 +67,29 @@ describe('health', () => {
         );
     });
 
-    it('GET /health handler responds with { status: "ok" }', () => {
+    it('GET /health handler reports ready when Discord is connected', () => {
+        vi.mocked(isBotReady).mockReturnValue(true);
         const handler = (mockApp.get.mock.calls as any[]).find(
             ([path]) => path === '/health',
         )?.[1];
         const res = { send: vi.fn() };
+
         handler({}, res);
+
         expect(res.send).toHaveBeenCalledWith({ status: 'ok' });
+    });
+
+    it('GET /health handler returns 503 until Discord is connected', () => {
+        const handler = (mockApp.get.mock.calls as any[]).find(
+            ([path]) => path === '/health',
+        )?.[1];
+        const send = vi.fn();
+        const status = vi.fn(() => ({ send }));
+
+        handler({}, { status });
+
+        expect(status).toHaveBeenCalledWith(503);
+        expect(send).toHaveBeenCalledWith({ status: 'not_ready' });
     });
 
     it('listens on port 3000', () => {

--- a/bot/test/utils/heartbeat.test.ts
+++ b/bot/test/utils/heartbeat.test.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import logger from '../../src/logging/logger';
+import { isBotReady } from '../../src/utils/botState';
 import { config } from '../../src/utils/config';
 import { startHeartbeat } from '../../src/utils/heartbeat';
 
@@ -8,6 +9,7 @@ vi.mock('axios');
 vi.mock('../../src/logging/logger', () => ({
     default: {
         info: vi.fn(),
+        debug: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
     },
@@ -19,12 +21,17 @@ vi.mock('../../src/utils/config', () => ({
     },
 }));
 
+vi.mock('../../src/utils/botState', () => ({
+    isBotReady: vi.fn(),
+}));
+
 const mockAxios = vi.mocked(axios, true);
 
 describe('heartbeat', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
+        vi.mocked(isBotReady).mockReturnValue(true);
     });
 
     afterEach(() => {
@@ -74,6 +81,25 @@ describe('heartbeat', () => {
 
         vi.advanceTimersByTime(60000);
         expect(mockAxios.get).toHaveBeenCalledTimes(3);
+    });
+
+    it('withholds heartbeats until the bot is ready', () => {
+        (config as any).BETTERSTACK_HEARTBEAT_URL =
+            'https://heartbeat.betterstack.com/test';
+        vi.mocked(isBotReady).mockReturnValue(false);
+
+        startHeartbeat();
+
+        expect(mockAxios.get).not.toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith(
+            { event: 'heartbeat.skipped', reason: 'bot_not_ready' },
+            'skipping BetterStack heartbeat while bot is not ready',
+        );
+
+        vi.mocked(isBotReady).mockReturnValue(true);
+        vi.advanceTimersByTime(60000);
+
+        expect(mockAxios.get).toHaveBeenCalledTimes(1);
     });
 
     it('logs error when heartbeat request fails', async () => {


### PR DESCRIPTION
Make bot health reflect the Discord connection so failed startup and disconnects are not reported as healthy.

## Changes
- Add a separate liveness endpoint and gate readiness on the Discord client
- Pause Better Stack heartbeats while the bot is unavailable

## Checklist
- [x] Bot and web tests
- [x] Typecheck, ESLint, Prettier, and Actionlint
