### PR TITLE
chore: refine Renovate dependency policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended"],
+    "extends": [
+        "config:recommended",
+        "helpers:pinGitHubActionDigests",
+        ":separateMultipleMajorReleases"
+    ],
     "baseBranchPatterns": ["master"],
     "dependencyDashboard": true,
     "configMigration": true,
@@ -9,7 +13,6 @@
     "prHourlyLimit": 0,
     "prConcurrentLimit": 3,
     "platformAutomerge": false,
-    "rangeStrategy": "pin",
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": false,
@@ -17,17 +20,40 @@
     },
     "packageRules": [
         {
+            "description": "Pin direct application dependencies",
             "matchManagers": ["npm"],
-            "matchDepTypes": ["engines"],
-            "rangeStrategy": "replace"
+            "matchDepTypes": [
+                "dependencies",
+                "devDependencies",
+                "optionalDependencies"
+            ],
+            "rangeStrategy": "pin"
+        },
+        {
+            "description": "Preserve compatibility ranges",
+            "matchManagers": ["npm"],
+            "matchDepTypes": ["engines", "peerDependencies"],
+            "rangeStrategy": "auto"
+        },
+        {
+            "description": "Keep Node.js on the supported release line",
+            "matchDatasources": ["node-version"],
+            "allowedVersions": ">=24 <25",
+            "groupName": "Node.js 24"
         },
         {
             "matchUpdateTypes": ["patch"],
             "groupName": "patch updates",
             "minimumReleaseAge": "5 days",
+            "minimumReleaseAgeBehaviour": "timestamp-required",
             "internalChecksFilter": "strict",
-            "prCreation": "not-pending",
             "automerge": true
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchUpdateTypes": ["pinDigest", "digest"],
+            "groupName": "GitHub Actions digests",
+            "dependencyDashboardApproval": true
         },
         {
             "matchUpdateTypes": ["minor"],
@@ -37,12 +63,6 @@
         {
             "matchUpdateTypes": ["major"],
             "dependencyDashboardApproval": true
-        },
-        {
-            "matchManagers": ["github-actions"],
-            "groupName": "github actions",
-            "minimumReleaseAge": "5 days",
-            "automerge": true
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended",
-        "helpers:pinGitHubActionDigests",
-        ":separateMultipleMajorReleases"
-    ],
+    "extends": ["config:best-practices", ":separateMultipleMajorReleases"],
     "baseBranchPatterns": ["master"],
     "dependencyDashboard": true,
     "configMigration": true,
@@ -13,6 +9,11 @@
     "prHourlyLimit": 0,
     "prConcurrentLimit": 3,
     "platformAutomerge": false,
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "groupName": "security updates",
+        "vulnerabilityFixStrategy": "lowest"
+    },
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": false,
@@ -44,14 +45,23 @@
         {
             "matchUpdateTypes": ["patch"],
             "groupName": "patch updates",
-            "minimumReleaseAge": "5 days",
+            "minimumReleaseAge": "14 days",
             "minimumReleaseAgeBehaviour": "timestamp-required",
             "internalChecksFilter": "strict",
             "automerge": true
         },
         {
+            "description": "Pin new GitHub Actions immediately",
             "matchManagers": ["github-actions"],
-            "matchUpdateTypes": ["pinDigest", "digest"],
+            "matchUpdateTypes": ["pinDigest"],
+            "groupName": "Pin GitHub Actions digests",
+            "schedule": ["at any time"],
+            "automerge": true
+        },
+        {
+            "description": "Review GitHub Actions digest changes",
+            "matchManagers": ["github-actions"],
+            "matchUpdateTypes": ["digest"],
             "groupName": "GitHub Actions digests",
             "dependencyDashboardApproval": true
         },


### PR DESCRIPTION
Refines Renovate to keep dependency updates secure without adding unnecessary PR churn. Direct dependencies stay pinned, security fixes are grouped, new Actions are pinned immediately, and routine updates follow safer cooldown and approval rules.