### PR TITLE
feat: show autocomplete cache status

### DIFF
--- a/bot/src/commands/utility/status.ts
+++ b/bot/src/commands/utility/status.ts
@@ -4,11 +4,33 @@ import {
     SlashCommandBuilder,
 } from 'discord.js';
 import {
+    autocompleteCache,
+    AutocompleteCacheStatus,
+} from '../../data/autocompleteCache';
+import {
     elapsedMs,
     errorLogFields,
     interactionLocation,
 } from '../../logging/fields';
 import logger from '../../logging/logger';
+
+function formatAutocompleteStatus(status: AutocompleteCacheStatus): string {
+    if (status.source === 'http') {
+        return 'Autocomplete data: **HTTP fallback**';
+    }
+
+    const updatedAt = Date.parse(status.updatedAt);
+    const updatedLabel = Number.isNaN(updatedAt)
+        ? 'at an unknown time'
+        : `<t:${Math.floor(updatedAt / 1000)}:R>`;
+    const revision = status.revision.slice(0, 12).replaceAll('`', '');
+
+    return (
+        `Autocomplete data: **local cache**\n` +
+        `Snapshot: \`${revision}\`, updated ${updatedLabel}\n` +
+        `Cached names: **${status.lifterCount.toLocaleString('en-US')} lifters** and **${status.meetCount.toLocaleString('en-US')} meets**`
+    );
+}
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -34,6 +56,7 @@ module.exports = {
             await client.guilds.fetch();
             const serverCount = client.guilds.cache.size;
             const userCount = client.users.cache.size;
+            const autocompleteStatus = autocompleteCache.getStatus();
 
             const embed = new EmbedBuilder()
                 .setColor('#c62932')
@@ -43,7 +66,8 @@ module.exports = {
                 .setDescription(
                     `Latency is **${latency}**ms\n\n` +
                         `Uptime: **${hours} hours** and **${minutes} minutes**\n` +
-                        `I am currently in **${serverCount} servers** with a total of **${userCount} users**\n\n` +
+                        `I am currently in **${serverCount} servers** with **${userCount} cached users**\n\n` +
+                        `${formatAutocompleteStatus(autocompleteStatus)}\n\n` +
                         `Credit to [OpenPowerlifting](https://www.openpowerlifting.org/) for data used`,
                 );
 
@@ -57,6 +81,11 @@ module.exports = {
                     serverCount,
                     cachedUserCount: userCount,
                     uptimeSeconds: Math.floor(uptimeInSeconds),
+                    autocompleteSource: autocompleteStatus.source,
+                    ...(autocompleteStatus.source === 'local' && {
+                        autocompleteRevision: autocompleteStatus.revision,
+                        autocompleteUpdatedAt: autocompleteStatus.updatedAt,
+                    }),
                     ...logContext,
                     duration_ms: elapsedMs(startedAt),
                 },

--- a/bot/src/data/autocompleteCache.ts
+++ b/bot/src/data/autocompleteCache.ts
@@ -25,6 +25,21 @@ type AutocompleteSnapshot = {
     meetNames: string[];
 };
 
+export type AutocompleteCacheStatus =
+    | {
+          source: 'local';
+          configured: true;
+          revision: string;
+          updatedAt: string;
+          loadedAt: string;
+          lifterCount: number;
+          meetCount: number;
+      }
+    | {
+          source: 'http';
+          configured: boolean;
+      };
+
 type CacheLogger = {
     debug(fields: Record<string, unknown>, message: string): void;
     info(fields: Record<string, unknown>, message: string): void;
@@ -173,6 +188,26 @@ export class AutocompleteCache {
 
     getSnapshot(): AutocompleteSnapshot | undefined {
         return this.snapshot;
+    }
+
+    getStatus(): AutocompleteCacheStatus {
+        const snapshot = this.snapshot;
+        if (!snapshot) {
+            return {
+                source: 'http',
+                configured: Boolean(this.options.bucket),
+            };
+        }
+
+        return {
+            source: 'local',
+            configured: true,
+            revision: snapshot.revision,
+            updatedAt: snapshot.updatedAt,
+            loadedAt: snapshot.loadedAt,
+            lifterCount: snapshot.lifterNames.length,
+            meetCount: snapshot.meetNames.length,
+        };
     }
 
     private async getAutocomplete(

--- a/bot/test/commands/status.test.ts
+++ b/bot/test/commands/status.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as statusCommand from '../../src/commands/utility/status';
+import { autocompleteCache } from '../../src/data/autocompleteCache';
 import logger from '../../src/logging/logger';
 
 vi.mock('discord.js');
+
+vi.mock('../../src/data/autocompleteCache', () => ({
+    autocompleteCache: {
+        getStatus: vi.fn(),
+    },
+}));
 
 vi.mock('../../src/logging/logger', () => ({
     default: {
@@ -39,6 +46,10 @@ describe('Status command', () => {
     beforeEach(() => {
         vi.mocked(logger.info).mockClear();
         vi.mocked(logger.error).mockClear();
+        vi.mocked(autocompleteCache.getStatus).mockReturnValue({
+            source: 'http',
+            configured: false,
+        });
     });
 
     it('replies to measure latency then edits reply with embed', async () => {
@@ -53,7 +64,7 @@ describe('Status command', () => {
         );
     });
 
-    it('embed description contains latency, server count, and user count', async () => {
+    it('embed description contains latency, server count, and cached user count', async () => {
         const interaction = makeInteraction(75);
         await execute(interaction as any);
 
@@ -61,7 +72,50 @@ describe('Status command', () => {
         const embed = embeds[0];
         expect(embed.description).toContain('ms');
         expect(embed.description).toContain('5 servers');
-        expect(embed.description).toContain('42 users');
+        expect(embed.description).toContain('42 cached users');
+        expect(embed.description).toContain('HTTP fallback');
+    });
+
+    it('shows local autocomplete snapshot metadata and counts', async () => {
+        vi.mocked(autocompleteCache.getStatus).mockReturnValue({
+            source: 'local',
+            configured: true,
+            revision: '1234567890abcdef',
+            updatedAt: '2026-05-24T00:00:00.000Z',
+            loadedAt: '2026-05-24T01:00:00.000Z',
+            lifterCount: 12_345,
+            meetCount: 678,
+        });
+        const interaction = makeInteraction();
+
+        await execute(interaction as any);
+
+        const { embeds } = (interaction.editReply as any).mock.calls[0][0];
+        const embed = embeds[0];
+        expect(embed.description).toContain('local cache');
+        expect(embed.description).toContain('`1234567890ab`');
+        expect(embed.description).toContain('<t:1779580800:R>');
+        expect(embed.description).toContain('12,345 lifters');
+        expect(embed.description).toContain('678 meets');
+    });
+
+    it('handles an invalid snapshot timestamp without emitting a broken Discord timestamp', async () => {
+        vi.mocked(autocompleteCache.getStatus).mockReturnValue({
+            source: 'local',
+            configured: true,
+            revision: 'rev1',
+            updatedAt: 'invalid',
+            loadedAt: '2026-05-24T01:00:00.000Z',
+            lifterCount: 1,
+            meetCount: 1,
+        });
+        const interaction = makeInteraction();
+
+        await execute(interaction as any);
+
+        const { embeds } = (interaction.editReply as any).mock.calls[0][0];
+        expect(embeds[0].description).toContain('updated at an unknown time');
+        expect(embeds[0].description).not.toContain('<t:NaN:R>');
     });
 
     it('fetches guilds before building the embed', async () => {

--- a/bot/test/data/autocompleteCache.test.ts
+++ b/bot/test/data/autocompleteCache.test.ts
@@ -144,6 +144,49 @@ describe('AutocompleteCache', () => {
         );
     });
 
+    it('reports local snapshot metadata without exposing cached names', async () => {
+        const { s3 } = makeS3(
+            makeObjects(
+                'rev1',
+                ['Samantha Rice', 'A Kandasamy'],
+                ['2025 USAPL Raw Nationals'],
+            ),
+        );
+        const cache = new AutocompleteCache({
+            s3,
+            bucket: 'test-bucket',
+            refreshIntervalSeconds: 300,
+            logger: makeLogger(),
+            now: () => new Date('2026-05-24T01:00:00.000Z'),
+        });
+
+        await cache.refresh();
+
+        expect(cache.getStatus()).toEqual({
+            source: 'local',
+            configured: true,
+            revision: 'rev1',
+            updatedAt: '2026-05-24T00:00:00.000Z',
+            loadedAt: '2026-05-24T01:00:00.000Z',
+            lifterCount: 2,
+            meetCount: 1,
+        });
+    });
+
+    it('reports HTTP fallback while a local snapshot is unavailable', () => {
+        const cache = new AutocompleteCache({
+            s3: makeS3({}).s3,
+            bucket: 'test-bucket',
+            refreshIntervalSeconds: 300,
+            logger: makeLogger(),
+        });
+
+        expect(cache.getStatus()).toEqual({
+            source: 'http',
+            configured: true,
+        });
+    });
+
     it('returns an empty array for an empty query without calling fallback', async () => {
         const logger = makeLogger();
         const { s3 } = makeS3(makeObjects('rev1', ['A Kandasamy'], []));


### PR DESCRIPTION
The status command now shows whether autocomplete is using the local snapshot or HTTP fallback, along with the snapshot revision, update time, and cached counts. This makes it easier to verify data rollouts without changing readiness or fallback behavior.