### PR TITLE
feat: show year in meet embed

### DIFF
--- a/bot/src/commands/opl/meet.ts
+++ b/bot/src/commands/opl/meet.ts
@@ -52,8 +52,13 @@ function escapeMarkdownText(value: string) {
     return value.replace(/([\\`*_{}\[\]()#+\-.!|>~])/g, '\\$1');
 }
 
-function formatMeetName(name: string, url: string | undefined) {
-    const escapedName = escapeMarkdownText(name);
+function formatMeetName(
+    year: string,
+    federation: string,
+    name: string,
+    url: string | undefined,
+) {
+    const escapedName = escapeMarkdownText(`${year} ${federation} ${name}`);
     return url ? `[**${escapedName}**](${url})` : `**${escapedName}**`;
 }
 
@@ -121,7 +126,12 @@ module.exports = {
 
             const entries = meet.entries.sort(compareDots);
             const meetUrl = getOpenPowerliftingMeetUrl(meet.url);
-            const meetName = formatMeetName(meet.name, meetUrl);
+            const meetName = formatMeetName(
+                meet.year,
+                meet.federation,
+                meet.name,
+                meetUrl,
+            );
 
             const embed = new EmbedBuilder()
                 .setColor(getEmbedColor())

--- a/bot/test/commands/meet.test.ts
+++ b/bot/test/commands/meet.test.ts
@@ -104,7 +104,7 @@ describe('Meet command', () => {
                     expect.objectContaining({
                         title: '🥇 Powerlifting Rankings',
                         description: expect.stringContaining(
-                            `Top lifters for [**Labors of Strength**](${mockSinglePageMeetUrl})`,
+                            `Top lifters for [**2025 IPF Labors of Strength**](${mockSinglePageMeetUrl})`,
                         ),
                         url: mockSinglePageMeetUrl,
                         fields: expect.any(Array),
@@ -127,7 +127,7 @@ describe('Meet command', () => {
         const { embeds } = vi.mocked(interaction.editReply).mock
             .calls[0][0] as any;
         expect(embeds[0].description).toContain(
-            'Top lifters for **Labors of Strength**',
+            'Top lifters for **2025 IPF Labors of Strength**',
         );
         expect(embeds[0].url).toBeUndefined();
     });
@@ -146,7 +146,7 @@ describe('Meet command', () => {
         const { embeds } = vi.mocked(interaction.editReply).mock
             .calls[0][0] as any;
         expect(embeds[0].description).toContain(
-            'Top lifters for **Labors of Strength**',
+            'Top lifters for **2025 IPF Labors of Strength**',
         );
         expect(embeds[0].url).toBeUndefined();
     });
@@ -165,7 +165,7 @@ describe('Meet command', () => {
         const { embeds } = vi.mocked(interaction.editReply).mock
             .calls[0][0] as any;
         expect(embeds[0].description).toContain(
-            'Top lifters for **Labors of Strength**',
+            'Top lifters for **2025 IPF Labors of Strength**',
         );
         expect(embeds[0].url).toBeUndefined();
     });
@@ -262,7 +262,7 @@ describe('Meet command', () => {
             .calls[0][0] as any;
         expect(embeds[0].description).toContain('page 2');
         expect(embeds[0].description).toContain(
-            `[**Multi Page Meet**](${mockMultiPageMeetUrl})`,
+            `[**2025 IPF Multi Page Meet**](${mockMultiPageMeetUrl})`,
         );
         expect(embeds[0].url).toBe(mockMultiPageMeetUrl);
     });


### PR DESCRIPTION
Meet embeds now show the year and federation before the meet name, matching OpenPowerlifting and autocomplete. Closes #236.