### PR TITLE
refactor: replace Axios with native fetch

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1053.0",
-    "axios": "1.16.1",
     "discord.js": "14.26.4",
     "dotenv": "17.4.2",
     "express": "5.2.1",

--- a/bot/src/data/apiClient.ts
+++ b/bot/src/data/apiClient.ts
@@ -1,14 +1,10 @@
-import axios from 'axios';
 import { elapsedMs, errorLogFields } from '../logging/fields';
 import logger from '../logging/logger';
 import type { Lifter, Meet, TopLifter } from '../types/types';
 import { config } from '../utils/config';
+import { fetchOk } from '../utils/http';
 
-const api = axios.create({
-    baseURL: config.API_BASE_URL,
-    timeout: 20000,
-    headers: { 'Content-Type': 'application/json' },
-});
+const API_REQUEST_TIMEOUT_MS = 20000;
 
 type ApiLogFields = Record<string, unknown>;
 
@@ -28,8 +24,18 @@ async function getFromApi<T>({
     const startedAt = Date.now();
 
     try {
-        const response = await api.get(route, { params });
-        const data = response.data as T;
+        const baseUrl = config.API_BASE_URL!.replace(/\/+$/, '');
+        const relativeRoute = route.replace(/^\/+/, '');
+        const url = new URL(`${baseUrl}/${relativeRoute}`);
+        for (const [key, value] of Object.entries(params)) {
+            url.searchParams.set(key, String(value));
+        }
+
+        const response = await fetchOk(url, {
+            headers: { Accept: 'application/json' },
+            signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
+        });
+        const data = (await response.json()) as T;
 
         logger.info(
             {

--- a/bot/src/logging/fields.ts
+++ b/bot/src/logging/fields.ts
@@ -3,21 +3,21 @@ type InteractionLocation = {
     channelId: string | null;
 };
 
-type AxiosErrorLike = Error & {
-    isAxiosError?: boolean;
-    code?: string;
-    status?: number;
-    response?: {
-        status?: number;
-    };
+type ErrorWithContext = Error & {
+    code?: unknown;
+    statusCode?: unknown;
+    cause?: unknown;
 };
 
-function isAxiosErrorLike(error: unknown): error is AxiosErrorLike {
-    return Boolean(
-        error &&
-        typeof error === 'object' &&
-        (error as Partial<AxiosErrorLike>).isAxiosError,
-    );
+function getErrorCode(error: ErrorWithContext): string | undefined {
+    if (typeof error.code === 'string') return error.code;
+
+    if (error.cause && typeof error.cause === 'object') {
+        const causeCode = (error.cause as { code?: unknown }).code;
+        if (typeof causeCode === 'string') return causeCode;
+    }
+
+    return undefined;
 }
 
 export function interactionLocation(interaction: InteractionLocation) {
@@ -28,17 +28,18 @@ export function interactionLocation(interaction: InteractionLocation) {
 }
 
 export function errorLogFields(error: unknown): Record<string, unknown> {
-    if (isAxiosErrorLike(error)) {
-        return {
-            errorType: 'AxiosError',
-            errorMessage: error.message,
-            errorCode: error.code,
-            statusCode: error.response?.status ?? error.status,
-        };
-    }
-
     if (error instanceof Error) {
-        return { err: error };
+        const contextualError = error as ErrorWithContext;
+        return {
+            err: error,
+            errorType: error.name,
+            errorMessage: error.message,
+            errorCode: getErrorCode(contextualError),
+            statusCode:
+                typeof contextualError.statusCode === 'number'
+                    ? contextualError.statusCode
+                    : undefined,
+        };
     }
 
     return {

--- a/bot/src/logging/logger.ts
+++ b/bot/src/logging/logger.ts
@@ -9,7 +9,6 @@ const redactPaths = [
     'request.headers',
     'req.headers',
     'config',
-    'axiosConfig',
     'response.headers',
     'response.body',
     'response.data',

--- a/bot/src/utils/heartbeat.ts
+++ b/bot/src/utils/heartbeat.ts
@@ -1,10 +1,11 @@
-import axios from 'axios';
 import { errorLogFields } from '../logging/fields';
 import logger from '../logging/logger';
 import { isBotReady } from './botState';
 import { config } from './config';
+import { discardResponseBody, fetchOk } from './http';
 
 const HEARTBEAT_INTERVAL = 60000; // 60 seconds
+const HEARTBEAT_TIMEOUT_MS = 5000;
 
 export function startHeartbeat() {
     if (!config.BETTERSTACK_HEARTBEAT_URL) {
@@ -36,7 +37,10 @@ async function sendHeartbeat() {
     }
 
     try {
-        await axios.get(config.BETTERSTACK_HEARTBEAT_URL!, { timeout: 5000 });
+        const response = await fetchOk(config.BETTERSTACK_HEARTBEAT_URL!, {
+            signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS),
+        });
+        await discardResponseBody(response);
     } catch (error) {
         logger.error(
             {

--- a/bot/src/utils/http.ts
+++ b/bot/src/utils/http.ts
@@ -1,0 +1,28 @@
+export class HttpResponseError extends Error {
+    constructor(readonly statusCode: number) {
+        super(`HTTP request failed with status ${statusCode}`);
+        this.name = 'HttpResponseError';
+    }
+}
+
+export async function discardResponseBody(response: Response): Promise<void> {
+    try {
+        await response.body?.cancel();
+    } catch {
+        // Cleanup is best effort and must not replace the request outcome.
+    }
+}
+
+export async function fetchOk(
+    input: string | URL,
+    init?: RequestInit,
+): Promise<Response> {
+    const response = await fetch(input, init);
+
+    if (!response.ok) {
+        await discardResponseBody(response);
+        throw new HttpResponseError(response.status);
+    }
+
+    return response;
+}

--- a/bot/test/data/apiClient.test.ts
+++ b/bot/test/data/apiClient.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     getLifter,
     getLifterAutocomplete,
@@ -8,6 +8,7 @@ import {
 } from '../../src/data/apiClient';
 import logger from '../../src/logging/logger';
 import { Lifter, Meet, TopLifter } from '../../src/types/types';
+import { config } from '../../src/utils/config';
 
 vi.mock('../../src/logging/logger', () => ({
     default: {
@@ -24,16 +25,16 @@ vi.mock('../../src/utils/config', () => ({
     },
 }));
 
-const mockGet = vi.hoisted(() => vi.fn());
+const mockFetch = vi.hoisted(() => vi.fn());
 
-vi.mock('axios', () => ({
-    default: {
-        create: vi.fn(() => ({
-            get: mockGet,
-            defaults: { baseURL: 'http://localhost:8080' },
-        })),
-    },
-}));
+vi.stubGlobal('fetch', mockFetch);
+
+function jsonResponse(data: unknown, status = 200) {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
 
 const mockLifter: Lifter = {
     name: 'Jane Doe',
@@ -122,20 +123,38 @@ const mockTopLifters: TopLifter[] = [
 
 describe('apiClient', () => {
     beforeEach(() => {
-        mockGet.mockReset();
-        vi.mocked(logger.error).mockClear();
+        (config as any).API_BASE_URL = 'http://localhost:8080';
+        mockFetch.mockReset();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('getLifter returns lifter data from the API', async () => {
-        mockGet.mockResolvedValueOnce({ data: mockLifter });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockLifter));
         const result = await getLifter('Jane Doe');
 
         expect(result).toEqual(mockLifter);
         expect(logger.error).not.toHaveBeenCalled();
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'api_client.request_completed',
+                route: '/api/lifters',
+                method: 'GET',
+                query: 'Jane Doe',
+                statusCode: 200,
+                found: true,
+                meetCount: 1,
+                duration_ms: expect.any(Number),
+            }),
+            'api client request completed',
+        );
     });
 
     it('getMeet returns meet data from the API', async () => {
-        mockGet.mockResolvedValueOnce({ data: mockMeet });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockMeet));
         const result = await getMeet('Mock Meet');
 
         expect(result).toEqual(mockMeet);
@@ -143,7 +162,7 @@ describe('apiClient', () => {
     });
 
     it('getTopLifters returns top lifter data from the API', async () => {
-        mockGet.mockResolvedValueOnce({ data: mockTopLifters });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockTopLifters));
         const result = await getTopLifters(1);
 
         expect(result).toEqual(mockTopLifters);
@@ -151,7 +170,7 @@ describe('apiClient', () => {
     });
 
     it('getLifter returns undefined and logs error on network failure', async () => {
-        mockGet.mockRejectedValueOnce(new Error('Network error'));
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
         const result = await getLifter('Jane Doe');
 
         expect(result).toBeUndefined();
@@ -161,13 +180,14 @@ describe('apiClient', () => {
                 route: '/api/lifters',
                 query: 'Jane Doe',
                 err: expect.any(Error),
+                errorType: 'Error',
             }),
             'api client request failed',
         );
     });
 
     it('getMeet returns undefined and logs error on network failure', async () => {
-        mockGet.mockRejectedValueOnce(new Error('Network error'));
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
         const result = await getMeet('Mock Meet');
 
         expect(result).toBeUndefined();
@@ -183,7 +203,7 @@ describe('apiClient', () => {
     });
 
     it('getTopLifters returns undefined and logs error on network failure', async () => {
-        mockGet.mockRejectedValueOnce(new Error('Network error'));
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
         const result = await getTopLifters(1);
 
         expect(result).toBeUndefined();
@@ -199,7 +219,9 @@ describe('apiClient', () => {
     });
 
     it('getLifterAutocomplete returns name suggestions from the API', async () => {
-        mockGet.mockResolvedValueOnce({ data: ['Jane Doe', 'Jane Smith'] });
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse(['Jane Doe', 'Jane Smith']),
+        );
         const result = await getLifterAutocomplete('Jane');
 
         expect(result).toEqual(['Jane Doe', 'Jane Smith']);
@@ -207,7 +229,7 @@ describe('apiClient', () => {
     });
 
     it('getLifterAutocomplete returns undefined and logs error on network failure', async () => {
-        mockGet.mockRejectedValueOnce(new Error('Network error'));
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
         const result = await getLifterAutocomplete('Jane');
 
         expect(result).toBeUndefined();
@@ -223,9 +245,9 @@ describe('apiClient', () => {
     });
 
     it('getMeetAutocomplete returns meet name suggestions from the API', async () => {
-        mockGet.mockResolvedValueOnce({
-            data: ['Mock Meet', 'Mock Meet 2'],
-        });
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse(['Mock Meet', 'Mock Meet 2']),
+        );
         const result = await getMeetAutocomplete('Mock');
 
         expect(result).toEqual(['Mock Meet', 'Mock Meet 2']);
@@ -233,7 +255,7 @@ describe('apiClient', () => {
     });
 
     it('getMeetAutocomplete returns undefined and logs error on network failure', async () => {
-        mockGet.mockRejectedValueOnce(new Error('Network error'));
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
         const result = await getMeetAutocomplete('Mock');
 
         expect(result).toBeUndefined();
@@ -243,6 +265,75 @@ describe('apiClient', () => {
                 route: '/api/meets/autocomplete',
                 query: 'Mock',
                 err: expect.any(Error),
+            }),
+            'api client request failed',
+        );
+    });
+
+    it('encodes query parameters and applies a request timeout', async () => {
+        const timeout = vi.spyOn(AbortSignal, 'timeout');
+        mockFetch.mockResolvedValueOnce(jsonResponse(['Jane Doe']));
+
+        await getLifterAutocomplete('Jane & John', 25);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            new URL(
+                'http://localhost:8080/api/lifters/autocomplete?query=Jane+%26+John&limit=25',
+            ),
+            {
+                headers: { Accept: 'application/json' },
+                signal: expect.any(AbortSignal),
+            },
+        );
+        expect(timeout).toHaveBeenCalledWith(20000);
+    });
+
+    it('preserves a path prefix in the API base URL', async () => {
+        (config as any).API_BASE_URL = 'http://localhost:8080/v2/';
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockLifter));
+
+        await getLifter('Jane Doe');
+
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).toEqual(
+            new URL('http://localhost:8080/v2/api/lifters?name=Jane+Doe'),
+        );
+    });
+
+    it('treats non-success responses as request failures', async () => {
+        mockFetch.mockResolvedValueOnce(
+            new Response('Service unavailable', { status: 503 }),
+        );
+
+        const result = await getLifter('Jane Doe');
+
+        expect(result).toBeUndefined();
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'api_client.request_failed',
+                route: '/api/lifters',
+                errorType: 'HttpResponseError',
+                statusCode: 503,
+            }),
+            'api client request failed',
+        );
+    });
+
+    it('logs timeout failures with their error type', async () => {
+        mockFetch.mockRejectedValueOnce(
+            new DOMException(
+                'The operation was aborted due to timeout',
+                'TimeoutError',
+            ),
+        );
+
+        const result = await getMeet('Mock Meet');
+
+        expect(result).toBeUndefined();
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'api_client.request_failed',
+                errorType: 'TimeoutError',
             }),
             'api client request failed',
         );

--- a/bot/test/logging/fields.test.ts
+++ b/bot/test/logging/fields.test.ts
@@ -4,35 +4,66 @@ import { errorLogFields } from '../../src/logging/fields';
 describe('errorLogFields', () => {
     it('returns err for a plain Error', () => {
         const error = new Error('something failed');
-        expect(errorLogFields(error)).toEqual({ err: error });
+        expect(errorLogFields(error)).toEqual({
+            err: error,
+            errorType: 'Error',
+            errorMessage: 'something failed',
+            errorCode: undefined,
+            statusCode: undefined,
+        });
     });
 
-    it('returns structured fields for an Axios-like error', () => {
+    it('returns structured fields for an HTTP response error', () => {
         const error = Object.assign(
             new Error('Request failed with status 503'),
             {
-                isAxiosError: true,
-                code: 'ECONNREFUSED',
-                response: { status: 503 },
+                name: 'HttpResponseError',
+                statusCode: 503,
             },
         );
         expect(errorLogFields(error)).toEqual({
-            errorType: 'AxiosError',
+            err: error,
+            errorType: 'HttpResponseError',
             errorMessage: 'Request failed with status 503',
-            errorCode: 'ECONNREFUSED',
+            errorCode: undefined,
             statusCode: 503,
         });
     });
 
-    it('falls back to status on the error itself when response is absent', () => {
-        const error = Object.assign(new Error('timeout'), {
-            isAxiosError: true,
-            code: 'ECONNABORTED',
-            status: 408,
+    it('extracts a network error code from the error cause', () => {
+        const cause = Object.assign(new Error('connection refused'), {
+            code: 'ECONNREFUSED',
         });
+        const error = new TypeError('fetch failed', { cause });
+
+        expect(errorLogFields(error)).toEqual({
+            err: error,
+            errorType: 'TypeError',
+            errorMessage: 'fetch failed',
+            errorCode: 'ECONNREFUSED',
+            statusCode: undefined,
+        });
+    });
+
+    it('extracts a network error code from the error itself', () => {
+        const error = Object.assign(new TypeError('fetch failed'), {
+            code: 'ECONNRESET',
+        });
+
         expect(errorLogFields(error)).toMatchObject({
-            errorType: 'AxiosError',
-            statusCode: 408,
+            errorType: 'TypeError',
+            errorCode: 'ECONNRESET',
+        });
+    });
+
+    it('ignores non-string error codes', () => {
+        const error = new TypeError('fetch failed', {
+            cause: { code: 500 },
+        });
+
+        expect(errorLogFields(error)).toMatchObject({
+            errorType: 'TypeError',
+            errorCode: undefined,
         });
     });
 

--- a/bot/test/utils/heartbeat.test.ts
+++ b/bot/test/utils/heartbeat.test.ts
@@ -1,11 +1,9 @@
-import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import logger from '../../src/logging/logger';
 import { isBotReady } from '../../src/utils/botState';
 import { config } from '../../src/utils/config';
 import { startHeartbeat } from '../../src/utils/heartbeat';
 
-vi.mock('axios');
 vi.mock('../../src/logging/logger', () => ({
     default: {
         info: vi.fn(),
@@ -25,16 +23,20 @@ vi.mock('../../src/utils/botState', () => ({
     isBotReady: vi.fn(),
 }));
 
-const mockAxios = vi.mocked(axios, true);
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal('fetch', mockFetch);
 
 describe('heartbeat', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockFetch.mockReset();
         vi.useFakeTimers();
         vi.mocked(isBotReady).mockReturnValue(true);
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         vi.useRealTimers();
     });
 
@@ -47,13 +49,14 @@ describe('heartbeat', () => {
             { event: 'heartbeat.unconfigured' },
             'BetterStack heartbeat URL not configured, skipping heartbeat',
         );
-        expect(mockAxios.get).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('starts heartbeat when URL is configured', () => {
+        const timeout = vi.spyOn(AbortSignal, 'timeout');
         (config as any).BETTERSTACK_HEARTBEAT_URL =
             'https://heartbeat.betterstack.com/test';
-        mockAxios.get.mockResolvedValue({ data: 'ok' });
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
 
         startHeartbeat();
 
@@ -61,26 +64,44 @@ describe('heartbeat', () => {
             { event: 'heartbeat.started', interval_ms: 60000 },
             'starting BetterStack heartbeat monitor',
         );
-        expect(mockAxios.get).toHaveBeenCalledWith(
+        expect(mockFetch).toHaveBeenCalledWith(
             'https://heartbeat.betterstack.com/test',
-            { timeout: 5000 },
+            { signal: expect.any(AbortSignal) },
         );
+        expect(timeout).toHaveBeenCalledWith(5000);
+    });
+
+    it('discards successful heartbeat response bodies', async () => {
+        (config as any).BETTERSTACK_HEARTBEAT_URL =
+            'https://heartbeat.betterstack.com/test';
+        const cancel = vi.fn().mockResolvedValue(undefined);
+        mockFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            body: { cancel },
+        } as unknown as Response);
+
+        startHeartbeat();
+
+        await vi.waitFor(() => {
+            expect(cancel).toHaveBeenCalledOnce();
+        });
     });
 
     it('sends heartbeat at 60-second intervals', async () => {
         (config as any).BETTERSTACK_HEARTBEAT_URL =
             'https://heartbeat.betterstack.com/test';
-        mockAxios.get.mockResolvedValue({ data: 'ok' });
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
 
         startHeartbeat();
 
-        expect(mockAxios.get).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
 
         vi.advanceTimersByTime(60000);
-        expect(mockAxios.get).toHaveBeenCalledTimes(2);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
 
         vi.advanceTimersByTime(60000);
-        expect(mockAxios.get).toHaveBeenCalledTimes(3);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
     it('withholds heartbeats until the bot is ready', () => {
@@ -90,7 +111,7 @@ describe('heartbeat', () => {
 
         startHeartbeat();
 
-        expect(mockAxios.get).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
         expect(logger.debug).toHaveBeenCalledWith(
             { event: 'heartbeat.skipped', reason: 'bot_not_ready' },
             'skipping BetterStack heartbeat while bot is not ready',
@@ -99,14 +120,14 @@ describe('heartbeat', () => {
         vi.mocked(isBotReady).mockReturnValue(true);
         vi.advanceTimersByTime(60000);
 
-        expect(mockAxios.get).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('logs error when heartbeat request fails', async () => {
         (config as any).BETTERSTACK_HEARTBEAT_URL =
             'https://heartbeat.betterstack.com/test';
         const error = new Error('Network error');
-        mockAxios.get.mockRejectedValue(error);
+        mockFetch.mockRejectedValue(error);
 
         startHeartbeat();
 
@@ -115,6 +136,27 @@ describe('heartbeat', () => {
                 expect.objectContaining({
                     event: 'heartbeat.failed',
                     err: error,
+                }),
+                'failed to send heartbeat to BetterStack',
+            );
+        });
+    });
+
+    it('logs non-success heartbeat responses with their status', async () => {
+        (config as any).BETTERSTACK_HEARTBEAT_URL =
+            'https://heartbeat.betterstack.com/test';
+        mockFetch.mockResolvedValue(
+            new Response('Service unavailable', { status: 503 }),
+        );
+
+        startHeartbeat();
+
+        await vi.waitFor(() => {
+            expect(logger.error).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'heartbeat.failed',
+                    errorType: 'HttpResponseError',
+                    statusCode: 503,
                 }),
                 'failed to send heartbeat to BetterStack',
             );

--- a/bot/test/utils/http.test.ts
+++ b/bot/test/utils/http.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchOk } from '../../src/utils/http';
+
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal('fetch', mockFetch);
+
+describe('fetchOk', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it('preserves the HTTP status when body cleanup fails', async () => {
+        const cancel = vi.fn().mockRejectedValue(new Error('cancel failed'));
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 503,
+            body: { cancel },
+        } as unknown as Response);
+
+        await expect(fetchOk('https://example.com')).rejects.toMatchObject({
+            name: 'HttpResponseError',
+            statusCode: 503,
+        });
+        expect(cancel).toHaveBeenCalledOnce();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@aws-sdk/client-s3':
         specifier: 3.1053.0
         version: 3.1053.0
-      axios:
-        specifier: 1.16.1
-        version: 1.16.1
       discord.js:
         specifier: 14.26.4
         version: 14.26.4
@@ -113,7 +110,7 @@ importers:
         version: 2.0.0(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.22)
       '@nuxt/ui':
         specifier: 4.8.0
-        version: 4.8.0(@internationalized/date@3.12.2)(@internationalized/number@3.6.7)(@tiptap/extensions@3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))(@tiptap/pm@3.27.4))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(axios@1.16.1)(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(rollup@4.62.2)(tailwindcss@4.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))(yjs@13.6.31)
+        version: 4.8.0(@internationalized/date@3.12.2)(@internationalized/number@3.6.7)(@tiptap/extensions@3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))(@tiptap/pm@3.27.4))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(rollup@4.62.2)(tailwindcss@4.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))(yjs@13.6.31)
       '@nuxtjs/tailwindcss':
         specifier: 7.0.0-beta.1
         version: 7.0.0-beta.1(magicast@0.5.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))
@@ -3041,10 +3038,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3119,9 +3112,6 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -3132,9 +3122,6 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: 8.5.15
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -3366,10 +3353,6 @@ packages:
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -3598,10 +3581,6 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -3769,10 +3748,6 @@ packages:
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.28.1:
@@ -4063,15 +4038,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   fontaine@0.8.0:
     resolution: {integrity: sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==}
     engines: {node: '>=18.12.0'}
@@ -4092,10 +4058,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data@4.0.6:
-    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
-    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -4244,10 +4206,6 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -4278,10 +4236,6 @@ packages:
   http-shutdown@1.2.2:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4733,16 +4687,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -5398,10 +5344,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
@@ -8221,7 +8163,7 @@ snapshots:
       - vite
       - webpack
 
-  '@nuxt/ui@4.8.0(@internationalized/date@3.12.2)(@internationalized/number@3.6.7)(@tiptap/extensions@3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))(@tiptap/pm@3.27.4))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(axios@1.16.1)(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(rollup@4.62.2)(tailwindcss@4.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))(yjs@13.6.31)':
+  '@nuxt/ui@4.8.0(@internationalized/date@3.12.2)(@internationalized/number@3.6.7)(@tiptap/extensions@3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))(@tiptap/pm@3.27.4))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(rollup@4.62.2)(tailwindcss@4.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))(yjs@13.6.31)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.39(typescript@6.0.3))
@@ -8254,7 +8196,7 @@ snapshots:
       '@tiptap/vue-3': 3.27.4(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))(@tiptap/pm@3.27.4)(vue@3.5.39(typescript@6.0.3))
       '@unhead/vue': 2.1.15(vue@3.5.39(typescript@6.0.3))
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
-      '@vueuse/integrations': 14.3.0(axios@1.16.1)(change-case@5.4.4)(fuse.js@7.5.0)(vue@3.5.39(typescript@6.0.3))
+      '@vueuse/integrations': 14.3.0(change-case@5.4.4)(fuse.js@7.5.0)(vue@3.5.39(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.5.39(typescript@6.0.3))
       colortranslator: 5.0.0
       consola: 3.4.2
@@ -9865,13 +9807,12 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.5.39(typescript@6.0.3))
       vue: 3.5.39(typescript@6.0.3)
 
-  '@vueuse/integrations@14.3.0(axios@1.16.1)(change-case@5.4.4)(fuse.js@7.5.0)(vue@3.5.39(typescript@6.0.3))':
+  '@vueuse/integrations@14.3.0(change-case@5.4.4)(fuse.js@7.5.0)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.5.39(typescript@6.0.3))
       vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
-      axios: 1.16.1
       change-case: 5.4.4
       fuse.js: 7.5.0
 
@@ -9916,12 +9857,6 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -10006,8 +9941,6 @@ snapshots:
 
   async@3.2.6: {}
 
-  asynckit@0.4.0: {}
-
   atomic-sleep@1.0.0: {}
 
   autoprefixer@10.5.3(postcss@8.5.15):
@@ -10018,16 +9951,6 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
-
-  axios@1.16.1:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   b4a@1.8.1: {}
 
@@ -10252,10 +10175,6 @@ snapshots:
 
   colortranslator@5.0.0: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@10.0.1: {}
 
   commander@11.1.0: {}
@@ -10455,8 +10374,6 @@ snapshots:
 
   defu@6.1.7: {}
 
-  delayed-stream@1.0.0: {}
-
   denque@2.1.0: {}
 
   depd@2.0.0: {}
@@ -10606,13 +10523,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -11004,8 +10914,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
-
   fontaine@0.8.0:
     dependencies:
       '@capsizecss/unpack': 4.0.1
@@ -11062,14 +10970,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  form-data@4.0.6:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -11201,10 +11101,6 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -11234,13 +11130,6 @@ snapshots:
       toidentifier: 1.0.1
 
   http-shutdown@1.2.2: {}
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -11715,13 +11604,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mime-db@1.52.0: {}
-
   mime-db@1.54.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -12611,8 +12494,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   pstree.remy@1.1.8: {}
 


### PR DESCRIPTION
Replaces Axios in the API client and heartbeat with Node's native fetch while keeping the existing timeouts and error logging. This also removes the direct dependency and adds coverage for status failures and response cleanup. Closes #368.