### PR TITLE
fix: clean up command correctness issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
               uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
               id: filter
               with:
+                  token: ''
                   filters: |
                       bot:
                           - 'bot/**'

--- a/bot/src/commands/opl/lifter.ts
+++ b/bot/src/commands/opl/lifter.ts
@@ -19,6 +19,26 @@ async function fetchLifter(name: string): Promise<Lifter | undefined> {
     return api.getLifter(name);
 }
 
+function formatPlacement(place: number): string {
+    const absolutePlace = Math.abs(place);
+    const lastTwoDigits = absolutePlace % 100;
+
+    if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
+        return `${place}th`;
+    }
+
+    const suffix =
+        absolutePlace % 10 === 1
+            ? 'st'
+            : absolutePlace % 10 === 2
+              ? 'nd'
+              : absolutePlace % 10 === 3
+                ? 'rd'
+                : 'th';
+
+    return `${place}${suffix}`;
+}
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('lifter')
@@ -104,7 +124,7 @@ module.exports = {
                 {
                     name: `\`${index + 1}.\` ${meet.federation} ${meet.name}`,
                     value: `
-                    ${meet.place}st Place${meet.state ? `, ${meet.state}` : ''}
+                    ${formatPlacement(meet.place)} Place${meet.state ? `, ${meet.state}` : ''}
                     Date: ${meet.date}
                     Age: ${meet.age ?? '—'}
                     Equip: ${meet.equipment}

--- a/bot/src/commands/opl/meet.ts
+++ b/bot/src/commands/opl/meet.ts
@@ -63,9 +63,9 @@ function formatMeetName(
 }
 
 function compareDots(a: Meet['entries'][0], b: Meet['entries'][0]): number {
-    if (!a.dots && !b.dots) return 0;
-    if (!a.dots) return 1;
-    if (!b.dots) return -1;
+    if (a.dots == null && b.dots == null) return 0;
+    if (a.dots == null) return 1;
+    if (b.dots == null) return -1;
     return b.dots - a.dots;
 }
 
@@ -124,7 +124,7 @@ module.exports = {
                 return;
             }
 
-            const entries = meet.entries.sort(compareDots);
+            const entries = meet.entries.toSorted(compareDots);
             const meetUrl = getOpenPowerliftingMeetUrl(meet.url);
             const meetName = formatMeetName(
                 meet.year,

--- a/bot/src/commands/utility/status.ts
+++ b/bot/src/commands/utility/status.ts
@@ -53,7 +53,6 @@ module.exports = {
             const minutes = Math.floor((uptimeInSeconds % 3600) / 60);
 
             const client = interaction.client;
-            await client.guilds.fetch();
             const serverCount = client.guilds.cache.size;
             const userCount = client.users.cache.size;
             const autocompleteStatus = autocompleteCache.getStatus();
@@ -66,7 +65,7 @@ module.exports = {
                 .setDescription(
                     `Latency is **${latency}**ms\n\n` +
                         `Uptime: **${hours} hours** and **${minutes} minutes**\n` +
-                        `I am currently in **${serverCount} servers** with **${userCount} cached users**\n\n` +
+                        `I currently have **${serverCount} cached servers** and **${userCount} cached users**\n\n` +
                         `${formatAutocompleteStatus(autocompleteStatus)}\n\n` +
                         `Credit to [OpenPowerlifting](https://www.openpowerlifting.org/) for data used`,
                 );
@@ -78,7 +77,7 @@ module.exports = {
                     commandName: 'status',
                     outcome: 'success',
                     latency_ms: latency,
-                    serverCount,
+                    cachedServerCount: serverCount,
                     cachedUserCount: userCount,
                     uptimeSeconds: Math.floor(uptimeInSeconds),
                     autocompleteSource: autocompleteStatus.source,

--- a/bot/test/commands/lifter.test.ts
+++ b/bot/test/commands/lifter.test.ts
@@ -91,6 +91,33 @@ describe('Lifter command', () => {
             );
         });
 
+        it.each([
+            [1, '1st'],
+            [2, '2nd'],
+            [3, '3rd'],
+            [4, '4th'],
+            [11, '11th'],
+            [12, '12th'],
+            [13, '13th'],
+            [21, '21st'],
+            [22, '22nd'],
+            [23, '23rd'],
+        ])('formats a placement of %i as %s', async (place, placement) => {
+            mockGetLifter.mockResolvedValue({
+                ...mockLifter,
+                meets: [{ ...mockLifter.meets[0], place }],
+            });
+            const interaction = createChatInputInteraction({
+                name: 'Heracles',
+            });
+
+            await execute(interaction);
+
+            const { embeds } = vi.mocked(interaction.editReply).mock
+                .calls[0][0] as any;
+            expect(embeds[0].fields[0].value).toContain(`${placement} Place`);
+        });
+
         it('replies with error when no name is provided', async () => {
             const interaction = createChatInputInteraction({ name: null });
             await execute(interaction);

--- a/bot/test/commands/meet.test.ts
+++ b/bot/test/commands/meet.test.ts
@@ -33,7 +33,7 @@ const mockSinglePageMeetUrl =
 const mockMultiPageMeetUrl =
     'https://www.openpowerlifting.org/m/ipf/GRC-2025-06-15-multi-page-meet';
 
-const makeEntry = (name: string, dots: number) => ({
+const makeEntry = (name: string, dots: number | null) => ({
     place: 1,
     name,
     sex: 'M',
@@ -112,6 +112,47 @@ describe('Meet command', () => {
                 ],
             }),
         );
+    });
+
+    it('sorts entries without changing the API response', async () => {
+        const meet = {
+            ...mockSinglePageMeet,
+            entries: [makeEntry('Lower', 400), makeEntry('Higher', 500)],
+        };
+        mockGetMeet.mockResolvedValue(meet);
+        const interaction = createChatInputInteraction({
+            name: 'Labors of Strength',
+        });
+
+        await execute(interaction);
+
+        expect(meet.entries.map((entry) => entry.name)).toEqual([
+            'Lower',
+            'Higher',
+        ]);
+        const { embeds } = vi.mocked(interaction.editReply).mock
+            .calls[0][0] as any;
+        expect(embeds[0].fields[0].name).toContain('Higher');
+        expect(embeds[0].fields[3].name).toContain('Lower');
+    });
+
+    it('sorts zero DOTS ahead of missing DOTS', async () => {
+        mockGetMeet.mockResolvedValue({
+            ...mockSinglePageMeet,
+            entries: [makeEntry('Missing', null), makeEntry('Zero', 0)],
+        });
+        const interaction = createChatInputInteraction({
+            name: 'Labors of Strength',
+        });
+
+        await execute(interaction);
+
+        const { embeds } = vi.mocked(interaction.editReply).mock
+            .calls[0][0] as any;
+        expect(embeds[0].fields[0].name).toContain('Zero');
+        expect(embeds[0].fields[1].value).toContain('Dots: 0.00');
+        expect(embeds[0].fields[3].name).toContain('Missing');
+        expect(embeds[0].fields[4].value).toContain('Dots: —');
     });
 
     it('does not link the meet name when url is missing', async () => {

--- a/bot/test/commands/status.test.ts
+++ b/bot/test/commands/status.test.ts
@@ -64,16 +64,23 @@ describe('Status command', () => {
         );
     });
 
-    it('embed description contains latency, server count, and cached user count', async () => {
+    it('labels cached server and user counts in the embed and logs', async () => {
         const interaction = makeInteraction(75);
         await execute(interaction as any);
 
         const { embeds } = (interaction.editReply as any).mock.calls[0][0];
         const embed = embeds[0];
         expect(embed.description).toContain('ms');
-        expect(embed.description).toContain('5 servers');
+        expect(embed.description).toContain('5 cached servers');
         expect(embed.description).toContain('42 cached users');
         expect(embed.description).toContain('HTTP fallback');
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cachedServerCount: 5,
+                cachedUserCount: 42,
+            }),
+            'command completed',
+        );
     });
 
     it('shows local autocomplete snapshot metadata and counts', async () => {
@@ -118,11 +125,11 @@ describe('Status command', () => {
         expect(embeds[0].description).not.toContain('<t:NaN:R>');
     });
 
-    it('fetches guilds before building the embed', async () => {
+    it('uses the guild cache without fetching every guild', async () => {
         const interaction = makeInteraction();
         await execute(interaction as any);
 
-        expect(interaction.client.guilds.fetch).toHaveBeenCalled();
+        expect(interaction.client.guilds.fetch).not.toHaveBeenCalled();
     });
 
     it('replies ephemerally with error when reply throws and interaction is not deferred', async () => {


### PR DESCRIPTION
Fixes ordinal placement labels, preserves API meet ordering, and handles zero DOTS correctly. The status command now uses clearly labeled cached counts without fetching every guild, and CI path filtering no longer depends on the pull request files API. Closes #376.