### PR TITLE
fix: sanitize Discord-facing text

### DIFF
--- a/bot/__mocks__/discord.js.ts
+++ b/bot/__mocks__/discord.js.ts
@@ -37,6 +37,18 @@ export class EmbedBuilder {
     url: unknown;
     fields: unknown[] = [];
 
+    get data() {
+        return {
+            author: this.author,
+            color: this.color,
+            title: this.title,
+            description: this.description,
+            footer: this.footer,
+            url: this.url,
+            fields: this.fields,
+        };
+    }
+
     setAuthor(author: unknown): this {
         this.author = author;
         return this;
@@ -68,6 +80,9 @@ export class EmbedBuilder {
     addFields(fields: unknown[]): this {
         this.fields = [...this.fields, ...fields];
         return this;
+    }
+    toJSON() {
+        return this.data;
     }
 }
 

--- a/bot/src/commands/opl/lifter.ts
+++ b/bot/src/commands/opl/lifter.ts
@@ -14,6 +14,14 @@ import {
 } from '../../logging/fields';
 import logger from '../../logging/logger';
 import { Lifter } from '../../types/types';
+import {
+    DISCORD_LIMITS,
+    enforceEmbedLimits,
+    escapeDiscordMarkdown,
+    formatDiscordCodeBlock,
+    sanitizeDiscordText,
+    truncateDiscordText,
+} from '../../utils/discord';
 
 async function fetchLifter(name: string): Promise<Lifter | undefined> {
     return api.getLifter(name);
@@ -80,9 +88,11 @@ module.exports = {
             const lifter: Lifter | undefined = await fetchLifter(name);
 
             if (!lifter || lifter.meets.length === 0) {
-                await interaction.editReply(
-                    `No data found for lifter: ${name}.`,
+                const notFoundMessage = truncateDiscordText(
+                    `No data found for lifter: ${escapeDiscordMarkdown(name)}.`,
+                    DISCORD_LIMITS.message,
                 );
+                await interaction.editReply(notFoundMessage);
                 logger.info(
                     {
                         event: 'command.completed',
@@ -100,19 +110,32 @@ module.exports = {
 
             const embed = new EmbedBuilder()
                 .setColor(getEmbedColor())
-                .setTitle(lifter.name)
+                .setTitle(
+                    sanitizeDiscordText(
+                        lifter.name,
+                        DISCORD_LIMITS.embed.title,
+                    ),
+                )
                 .setFooter({ text: getEmbedFooter() });
 
-            let formattedPersonalBests;
             if (lifter.personalBests && lifter.personalBests.length > 0) {
-                formattedPersonalBests = lifter.personalBests
-                    .map(
-                        (pb) =>
-                            `\`\`\`Equipment: ${pb.equipment}\nS: ${pb.squat ?? ''} B: ${pb.bench ?? ''} D: ${pb.deadlift ?? ''} Total: ${pb.total} DOTS: ${pb.dots}\`\`\``,
-                    )
-                    .join('');
+                const heading = '**Personal Bests**\n';
+                let remaining =
+                    DISCORD_LIMITS.embed.description - heading.length;
+                const personalBestBlocks: string[] = [];
+
+                for (const pb of lifter.personalBests) {
+                    if (remaining <= 6) break;
+                    const block = formatDiscordCodeBlock(
+                        `Equipment: ${pb.equipment}\nS: ${pb.squat ?? ''} B: ${pb.bench ?? ''} D: ${pb.deadlift ?? ''} Total: ${pb.total} DOTS: ${pb.dots}`,
+                        remaining,
+                    );
+                    personalBestBlocks.push(block);
+                    remaining -= block.length;
+                }
+
                 embed.setDescription(
-                    `**Personal Bests**\n${formattedPersonalBests}`,
+                    `${heading}${personalBestBlocks.join('')}`,
                 );
             }
 
@@ -122,19 +145,28 @@ module.exports = {
 
             const fields = lifter.meets.slice(0, 3).flatMap((meet, index) => [
                 {
-                    name: `\`${index + 1}.\` ${meet.federation} ${meet.name}`,
-                    value: `
-                    ${formatPlacement(meet.place)} Place${meet.state ? `, ${meet.state}` : ''}
-                    Date: ${meet.date}
+                    name: truncateDiscordText(
+                        `\`${index + 1}.\` ${escapeDiscordMarkdown(meet.federation)} ${escapeDiscordMarkdown(meet.name)}`,
+                        DISCORD_LIMITS.embed.fieldName,
+                    ),
+                    value: truncateDiscordText(
+                        `
+                    ${formatPlacement(meet.place)} Place${meet.state ? `, ${escapeDiscordMarkdown(meet.state)}` : ''}
+                    Date: ${escapeDiscordMarkdown(meet.date)}
                     Age: ${meet.age ?? '—'}
-                    Equip: ${meet.equipment}
+                    Equip: ${escapeDiscordMarkdown(meet.equipment)}
                     Class: ${meet.weightClass ?? '—'}
                     Weight: ${meet.bodyWeight ?? '—'}`,
+                        DISCORD_LIMITS.embed.fieldValue,
+                    ),
                     inline: true,
                 },
                 {
                     name: `\u200B`,
-                    value: `\`\`\`Squat: ${meet.squat ?? '—'}\nBench: ${meet.bench ?? '—'}\nDead: ${meet.deadlift ?? '—'}\n\nTotal: ${meet.total ?? '—'}\nDOTS: ${meet.dots ?? '—'}\`\`\``,
+                    value: formatDiscordCodeBlock(
+                        `Squat: ${meet.squat ?? '—'}\nBench: ${meet.bench ?? '—'}\nDead: ${meet.deadlift ?? '—'}\n\nTotal: ${meet.total ?? '—'}\nDOTS: ${meet.dots ?? '—'}`,
+                        DISCORD_LIMITS.embed.fieldValue,
+                    ),
                     inline: true,
                 },
                 {
@@ -145,6 +177,7 @@ module.exports = {
             ]);
 
             embed.addFields(fields);
+            enforceEmbedLimits(embed);
 
             await interaction.editReply({ embeds: [embed] });
             logger.info(

--- a/bot/src/commands/opl/meet.ts
+++ b/bot/src/commands/opl/meet.ts
@@ -16,6 +16,12 @@ import {
 } from '../../logging/fields';
 import logger from '../../logging/logger';
 import { Meet } from '../../types/types';
+import {
+    DISCORD_LIMITS,
+    enforceEmbedLimits,
+    escapeDiscordMarkdown,
+    truncateDiscordText,
+} from '../../utils/discord';
 
 const OPL_MEET_PATH_PATTERN =
     /^[A-Za-z0-9][A-Za-z0-9._~-]*(\/[A-Za-z0-9][A-Za-z0-9._~-]*)+$/;
@@ -48,18 +54,27 @@ function getOpenPowerliftingMeetUrl(url: string | null | undefined) {
     }
 }
 
-function escapeMarkdownText(value: string) {
-    return value.replace(/([\\`*_{}\[\]()#+\-.!|>~])/g, '\\$1');
-}
-
 function formatMeetName(
     year: string,
     federation: string,
     name: string,
     url: string | undefined,
+    maxLength: number,
 ) {
-    const escapedName = escapeMarkdownText(`${year} ${federation} ${name}`);
-    return url ? `[**${escapedName}**](${url})` : `**${escapedName}**`;
+    const escapedName = escapeDiscordMarkdown(`${year} ${federation} ${name}`);
+    const boldOverhead = 4;
+    const linkOverhead = url ? url.length + 8 : Number.POSITIVE_INFINITY;
+
+    if (url && linkOverhead < maxLength) {
+        const label = truncateDiscordText(
+            escapedName,
+            maxLength - linkOverhead,
+        );
+        return `[**${label}**](${url})`;
+    }
+
+    const label = truncateDiscordText(escapedName, maxLength - boldOverhead);
+    return `**${label}**`;
 }
 
 function compareDots(a: Meet['entries'][0], b: Meet['entries'][0]): number {
@@ -108,7 +123,11 @@ module.exports = {
             const meet: Meet | undefined = await fetchMeet(name);
 
             if (!meet || meet.entries.length === 0) {
-                await interaction.editReply(`No data found for meet: ${name}.`);
+                const notFoundMessage = truncateDiscordText(
+                    `No data found for meet: ${escapeDiscordMarkdown(name)}.`,
+                    DISCORD_LIMITS.message,
+                );
+                await interaction.editReply(notFoundMessage);
                 logger.info(
                     {
                         event: 'command.completed',
@@ -126,12 +145,6 @@ module.exports = {
 
             const entries = meet.entries.toSorted(compareDots);
             const meetUrl = getOpenPowerliftingMeetUrl(meet.url);
-            const meetName = formatMeetName(
-                meet.year,
-                meet.federation,
-                meet.name,
-                meetUrl,
-            );
 
             const embed = new EmbedBuilder()
                 .setColor(getEmbedColor())
@@ -151,7 +164,10 @@ module.exports = {
                 const pageEntries = entries.slice(offset, offset + pageSize);
                 const fields = pageEntries.flatMap((entry, index) => [
                     {
-                        name: `\`${offset + index + 1}.\` ${entry.name}`,
+                        name: truncateDiscordText(
+                            `\`${offset + index + 1}.\` ${escapeDiscordMarkdown(entry.name)}`,
+                            DISCORD_LIMITS.embed.fieldName,
+                        ),
                         value: `Squat: ${entry.squat ?? '—'} | Bench: ${entry.bench ?? '—'} | Deadlift: ${entry.deadlift ?? '—'}`,
                         inline: true,
                     },
@@ -167,9 +183,19 @@ module.exports = {
                     },
                 ]);
                 embed.setFields(fields);
-                embed.setDescription(
-                    `Top lifters for ${meetName}, page ${page}`,
+                const prefix = 'Top lifters for ';
+                const suffix = `, page ${page}`;
+                const meetName = formatMeetName(
+                    meet.year,
+                    meet.federation,
+                    meet.name,
+                    meetUrl,
+                    DISCORD_LIMITS.embed.description -
+                        prefix.length -
+                        suffix.length,
                 );
+                embed.setDescription(`${prefix}${meetName}${suffix}`);
+                enforceEmbedLimits(embed);
             };
 
             updateFields(1);

--- a/bot/src/commands/opl/top.ts
+++ b/bot/src/commands/opl/top.ts
@@ -15,6 +15,12 @@ import {
 } from '../../logging/fields';
 import logger from '../../logging/logger';
 import { TopLifter } from '../../types/types';
+import {
+    DISCORD_LIMITS,
+    enforceEmbedLimits,
+    escapeDiscordMarkdown,
+    truncateDiscordText,
+} from '../../utils/discord';
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -65,7 +71,10 @@ module.exports = {
 
                 const fields = pageLifters.flatMap((lifter, index) => [
                     {
-                        name: `\`${startIndex + index + 1}.\` ${lifter.name} (${lifter.sex})`,
+                        name: truncateDiscordText(
+                            `\`${startIndex + index + 1}.\` ${escapeDiscordMarkdown(lifter.name)} (${escapeDiscordMarkdown(lifter.sex)})`,
+                            DISCORD_LIMITS.embed.fieldName,
+                        ),
                         value: `squat: ${lifter.squat ?? '—'} | bench: ${lifter.bench ?? '—'} | deadlift: ${lifter.deadlift ?? '—'}`,
                         inline: true,
                     },
@@ -85,6 +94,7 @@ module.exports = {
                 embed.setDescription(
                     `Top lifters sorted by dots - Page ${page} of ${maxPages}`,
                 );
+                enforceEmbedLimits(embed);
             };
 
             updatePage(currentPage);

--- a/bot/src/commands/utility/status.ts
+++ b/bot/src/commands/utility/status.ts
@@ -13,6 +13,7 @@ import {
     interactionLocation,
 } from '../../logging/fields';
 import logger from '../../logging/logger';
+import { enforceEmbedLimits } from '../../utils/discord';
 
 function formatAutocompleteStatus(status: AutocompleteCacheStatus): string {
     if (status.source === 'http') {
@@ -69,6 +70,7 @@ module.exports = {
                         `${formatAutocompleteStatus(autocompleteStatus)}\n\n` +
                         `Credit to [OpenPowerlifting](https://www.openpowerlifting.org/) for data used`,
                 );
+            enforceEmbedLimits(embed);
 
             await interaction.editReply({ content: null, embeds: [embed] });
             logger.info(

--- a/bot/src/constants/client.ts
+++ b/bot/src/constants/client.ts
@@ -1,0 +1,9 @@
+import { ClientOptions, GatewayIntentBits } from 'discord.js';
+
+export const discordClientOptions = {
+    intents: [GatewayIntentBits.Guilds],
+    allowedMentions: {
+        parse: [],
+        repliedUser: false,
+    },
+} satisfies ClientOptions;

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { Client, Collection, GatewayIntentBits } from 'discord.js';
+import { Client, Collection } from 'discord.js';
+import { discordClientOptions } from './constants/client';
 import { startApiDataRefresh } from './data/api';
 import { deployCommands } from './deploy-commands';
 import logger from './logging/logger';
@@ -42,9 +43,7 @@ async function initializeBot() {
         return;
     }
 
-    const client = new Client({
-        intents: [GatewayIntentBits.Guilds],
-    });
+    const client = new Client(discordClientOptions);
     setDiscordClient(client);
 
     client.commands = new Collection<string, Command>();

--- a/bot/src/utils/discord.ts
+++ b/bot/src/utils/discord.ts
@@ -1,0 +1,171 @@
+import type { APIEmbed, APIEmbedField, EmbedBuilder } from 'discord.js';
+
+export const DISCORD_LIMITS = {
+    message: 2_000,
+    embed: {
+        title: 256,
+        description: 4_096,
+        authorName: 256,
+        footerText: 2_048,
+        fieldName: 256,
+        fieldValue: 1_024,
+        fields: 25,
+        total: 6_000,
+    },
+} as const;
+
+export function escapeDiscordMarkdown(value: string): string {
+    return value.replace(/([\\`*_{}\[\]()#+\-.!|>~])/g, '\\$1');
+}
+
+export function escapeDiscordCodeBlock(value: string): string {
+    return value.replaceAll('`', '`\u200B');
+}
+
+export function formatDiscordCodeBlock(
+    value: string,
+    maxLength: number,
+): string {
+    const wrapperLength = 6;
+    if (maxLength <= wrapperLength) {
+        throw new RangeError('maxLength must leave room for a code block');
+    }
+
+    const content = truncateDiscordText(
+        escapeDiscordCodeBlock(value),
+        maxLength - wrapperLength,
+    );
+    return `\`\`\`${content}\`\`\``;
+}
+
+export function truncateDiscordText(value: string, maxLength: number): string {
+    if (!Number.isInteger(maxLength) || maxLength < 1) {
+        throw new RangeError('maxLength must be a positive integer');
+    }
+
+    if (value.length <= maxLength) return value;
+    if (maxLength === 1) return '…';
+
+    let truncated = value.slice(0, maxLength - 1);
+    const finalCodeUnit = truncated.charCodeAt(truncated.length - 1);
+    if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+        truncated = truncated.slice(0, -1);
+    }
+
+    truncated = truncated.replace(/\\+$/, '');
+    return `${truncated}…`;
+}
+
+export function sanitizeDiscordText(value: string, maxLength: number): string {
+    return truncateDiscordText(escapeDiscordMarkdown(value), maxLength);
+}
+
+function countEmbedCharacters(embed: APIEmbed): number {
+    return (
+        (embed.title?.length ?? 0) +
+        (embed.description?.length ?? 0) +
+        (embed.author?.name.length ?? 0) +
+        (embed.footer?.text.length ?? 0) +
+        (embed.fields?.reduce(
+            (total, field) => total + field.name.length + field.value.length,
+            0,
+        ) ?? 0)
+    );
+}
+
+function shrinkText(
+    value: string,
+    excess: number,
+    minimumLength: number,
+): { value: string; excess: number } {
+    if (excess <= 0 || value.length <= minimumLength) {
+        return { value, excess };
+    }
+
+    const targetLength = Math.max(minimumLength, value.length - excess);
+    const shortened = truncateDiscordText(value, targetLength);
+    return {
+        value: shortened,
+        excess: excess - (value.length - shortened.length),
+    };
+}
+
+export function enforceEmbedLimits(embed: EmbedBuilder): EmbedBuilder {
+    const data = embed.data;
+    const fields: APIEmbedField[] = (data.fields ?? [])
+        .slice(0, DISCORD_LIMITS.embed.fields)
+        .map((field) => ({
+            ...field,
+            name: truncateDiscordText(
+                field.name,
+                DISCORD_LIMITS.embed.fieldName,
+            ),
+            value: truncateDiscordText(
+                field.value,
+                DISCORD_LIMITS.embed.fieldValue,
+            ),
+        }));
+
+    if (data.title) {
+        embed.setTitle(
+            truncateDiscordText(data.title, DISCORD_LIMITS.embed.title),
+        );
+    }
+    if (data.description) {
+        embed.setDescription(
+            truncateDiscordText(
+                data.description,
+                DISCORD_LIMITS.embed.description,
+            ),
+        );
+    }
+    if (data.author) {
+        embed.setAuthor({
+            name: truncateDiscordText(
+                data.author.name,
+                DISCORD_LIMITS.embed.authorName,
+            ),
+            iconURL: data.author.icon_url,
+            url: data.author.url,
+        });
+    }
+    if (data.footer) {
+        embed.setFooter({
+            text: truncateDiscordText(
+                data.footer.text,
+                DISCORD_LIMITS.embed.footerText,
+            ),
+            iconURL: data.footer.icon_url,
+        });
+    }
+    embed.setFields(fields);
+
+    let excess =
+        countEmbedCharacters(embed.toJSON()) - DISCORD_LIMITS.embed.total;
+    if (excess <= 0) return embed;
+
+    for (let index = fields.length - 1; index >= 0 && excess > 0; index--) {
+        const valueResult = shrinkText(fields[index].value, excess, 1);
+        fields[index].value = valueResult.value;
+        excess = valueResult.excess;
+
+        const nameResult = shrinkText(fields[index].name, excess, 1);
+        fields[index].name = nameResult.value;
+        excess = nameResult.excess;
+    }
+    embed.setFields(fields);
+
+    if (excess > 0 && embed.toJSON().description) {
+        const currentDescription = embed.toJSON().description!;
+        const result = shrinkText(currentDescription, excess, 1);
+        embed.setDescription(result.value);
+        excess = result.excess;
+    }
+
+    if (excess > 0 && embed.toJSON().title) {
+        const currentTitle = embed.toJSON().title!;
+        embed.setTitle(shrinkText(currentTitle, excess, 1).value);
+    }
+
+    return embed;
+}

--- a/bot/src/utils/discord.ts
+++ b/bot/src/utils/discord.ts
@@ -15,7 +15,9 @@ export const DISCORD_LIMITS = {
 } as const;
 
 export function escapeDiscordMarkdown(value: string): string {
-    return value.replace(/([\\`*_{}\[\]()#+\-.!|>~])/g, '\\$1');
+    return value
+        .replace(/@(everyone|here)\b/g, '@\u200B$1')
+        .replace(/([\\`*_{}\[\]()#+\-.!|>~])/g, '\\$1');
 }
 
 export function escapeDiscordCodeBlock(value: string): string {
@@ -144,6 +146,27 @@ export function enforceEmbedLimits(embed: EmbedBuilder): EmbedBuilder {
         countEmbedCharacters(embed.toJSON()) - DISCORD_LIMITS.embed.total;
     if (excess <= 0) return embed;
 
+    if (embed.toJSON().footer) {
+        const currentFooter = embed.toJSON().footer!;
+        const result = shrinkText(currentFooter.text, excess, 1);
+        embed.setFooter({
+            text: result.value,
+            iconURL: currentFooter.icon_url,
+        });
+        excess = result.excess;
+    }
+
+    if (excess > 0 && embed.toJSON().author) {
+        const currentAuthor = embed.toJSON().author!;
+        const result = shrinkText(currentAuthor.name, excess, 1);
+        embed.setAuthor({
+            name: result.value,
+            iconURL: currentAuthor.icon_url,
+            url: currentAuthor.url,
+        });
+        excess = result.excess;
+    }
+
     for (let index = fields.length - 1; index >= 0 && excess > 0; index--) {
         const valueResult = shrinkText(fields[index].value, excess, 1);
         fields[index].value = valueResult.value;
@@ -164,7 +187,9 @@ export function enforceEmbedLimits(embed: EmbedBuilder): EmbedBuilder {
 
     if (excess > 0 && embed.toJSON().title) {
         const currentTitle = embed.toJSON().title!;
-        embed.setTitle(shrinkText(currentTitle, excess, 1).value);
+        const result = shrinkText(currentTitle, excess, 1);
+        embed.setTitle(result.value);
+        excess = result.excess;
     }
 
     return embed;

--- a/bot/test/commands/lifter.test.ts
+++ b/bot/test/commands/lifter.test.ts
@@ -91,6 +91,46 @@ describe('Lifter command', () => {
             );
         });
 
+        it('escapes and limits untrusted lifter data', async () => {
+            mockGetLifter.mockResolvedValue({
+                ...mockLifter,
+                name: `**<@123> ${'x'.repeat(300)}`,
+                meets: [
+                    {
+                        ...mockLifter.meets[0],
+                        federation: '**IPF**',
+                        name: '<@123> Championship',
+                        state: '*Attica*',
+                        equipment: 'Raw```@everyone',
+                        date: '**<@789>**',
+                    },
+                ],
+                personalBests: [
+                    {
+                        ...mockLifter.personalBests[0],
+                        equipment: `Raw\`\`\`${'x'.repeat(5_000)}`,
+                    },
+                ],
+            });
+            const interaction = createChatInputInteraction({ name: 'unsafe' });
+
+            await execute(interaction);
+
+            const { embeds } = vi.mocked(interaction.editReply).mock
+                .calls[0][0] as any;
+            const embed = embeds[0];
+            expect(embed.title.length).toBeLessThanOrEqual(256);
+            expect(embed.title).toContain('\\*\\*<@123\\>');
+            expect(embed.description.length).toBeLessThanOrEqual(4_096);
+            expect(embed.description).toContain('\u200B');
+            expect(embed.fields[0].name.length).toBeLessThanOrEqual(256);
+            expect(embed.fields[0].name).toContain('\\*\\*IPF\\*\\*');
+            expect(embed.fields[0].value).toContain('\\*Attica\\*');
+            expect(embed.fields[0].value).toContain(
+                'Date: \\*\\*<@789\\>\\*\\*',
+            );
+        });
+
         it.each([
             [1, '1st'],
             [2, '2nd'],
@@ -138,6 +178,19 @@ describe('Lifter command', () => {
             expect(interaction.deferReply).toHaveBeenCalled();
             expect(interaction.editReply).toHaveBeenCalledWith(
                 'No data found for lifter: UnknownLifter.',
+            );
+        });
+
+        it('escapes user input in the not-found message', async () => {
+            mockGetLifter.mockResolvedValue(undefined);
+            const interaction = createChatInputInteraction({
+                name: '<@123> **Unknown**',
+            });
+
+            await execute(interaction);
+
+            expect(interaction.editReply).toHaveBeenCalledWith(
+                'No data found for lifter: <@123\\> \\*\\*Unknown\\*\\*.',
             );
         });
 

--- a/bot/test/commands/meet.test.ts
+++ b/bot/test/commands/meet.test.ts
@@ -114,6 +114,27 @@ describe('Meet command', () => {
         );
     });
 
+    it('escapes and limits untrusted meet data', async () => {
+        mockGetMeet.mockResolvedValue({
+            ...mockSinglePageMeet,
+            name: `**<@123> ${'x'.repeat(5_000)}`,
+            federation: '*IPF*',
+            entries: [makeEntry('**<@456> Lifter**', 500)],
+        });
+        const interaction = createChatInputInteraction({ name: 'unsafe' });
+
+        await execute(interaction);
+
+        const { embeds } = vi.mocked(interaction.editReply).mock
+            .calls[0][0] as any;
+        const embed = embeds[0];
+        expect(embed.description.length).toBeLessThanOrEqual(4_096);
+        expect(embed.description).toContain('\\*IPF\\*');
+        expect(embed.description).toContain('\\*\\*<@123\\>');
+        expect(embed.fields[0].name.length).toBeLessThanOrEqual(256);
+        expect(embed.fields[0].name).toContain('\\*\\*<@456\\>');
+    });
+
     it('sorts entries without changing the API response', async () => {
         const meet = {
             ...mockSinglePageMeet,
@@ -231,6 +252,19 @@ describe('Meet command', () => {
         expect(interaction.deferReply).toHaveBeenCalled();
         expect(interaction.editReply).toHaveBeenCalledWith(
             'No data found for meet: NonExistentMeet.',
+        );
+    });
+
+    it('escapes user input in the not-found message', async () => {
+        mockGetMeet.mockResolvedValue(undefined);
+        const interaction = createChatInputInteraction({
+            name: '<@123> **Unknown**',
+        });
+
+        await execute(interaction);
+
+        expect(interaction.editReply).toHaveBeenCalledWith(
+            'No data found for meet: <@123\\> \\*\\*Unknown\\*\\*.',
         );
     });
 

--- a/bot/test/commands/top.test.ts
+++ b/bot/test/commands/top.test.ts
@@ -122,6 +122,25 @@ describe('Top command', () => {
         );
     });
 
+    it('escapes and limits untrusted lifter names', async () => {
+        mockGetTopLifters.mockResolvedValue([
+            {
+                ...makeLifter('unsafe', 500),
+                name: '**<@123> Unsafe**',
+                sex: '*M*',
+            },
+        ]);
+        const interaction = createChatInputInteraction();
+
+        await execute(interaction);
+
+        const { embeds } = vi.mocked(interaction.editReply).mock
+            .calls[0][0] as any;
+        expect(embeds[0].fields[0].name.length).toBeLessThanOrEqual(256);
+        expect(embeds[0].fields[0].name).toContain('\\*\\*<@123\\>');
+        expect(embeds[0].fields[0].name).toContain('(\\*M\\*)');
+    });
+
     it('sets up a message component collector after replying', async () => {
         mockGetTopLifters.mockResolvedValue(mockTopLifters);
         const interaction = createChatInputInteraction();

--- a/bot/test/constants/client.test.ts
+++ b/bot/test/constants/client.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { discordClientOptions } from '../../src/constants/client';
+
+describe('discordClientOptions', () => {
+    it('disables all mentions by default', () => {
+        expect(discordClientOptions.allowedMentions).toEqual({
+            parse: [],
+            repliedUser: false,
+        });
+    });
+});

--- a/bot/test/utils/discord.test.ts
+++ b/bot/test/utils/discord.test.ts
@@ -1,0 +1,95 @@
+import { EmbedBuilder } from 'discord.js';
+import { describe, expect, it } from 'vitest';
+import {
+    DISCORD_LIMITS,
+    enforceEmbedLimits,
+    escapeDiscordCodeBlock,
+    escapeDiscordMarkdown,
+    formatDiscordCodeBlock,
+    sanitizeDiscordText,
+    truncateDiscordText,
+} from '../../src/utils/discord';
+
+const countEmbedCharacters = (embed: ReturnType<EmbedBuilder['toJSON']>) =>
+    (embed.title?.length ?? 0) +
+    (embed.description?.length ?? 0) +
+    (embed.author?.name.length ?? 0) +
+    (embed.footer?.text.length ?? 0) +
+    (embed.fields?.reduce(
+        (total, field) => total + field.name.length + field.value.length,
+        0,
+    ) ?? 0);
+
+describe('Discord text utilities', () => {
+    it('escapes Discord markdown and mention syntax', () => {
+        expect(escapeDiscordMarkdown('<@123> **bold** [link](url)')).toBe(
+            '<@123\\> \\*\\*bold\\*\\* \\[link\\]\\(url\\)',
+        );
+    });
+
+    it('breaks embedded code block fences', () => {
+        const escaped = escapeDiscordCodeBlock('before```after');
+
+        expect(escaped).not.toContain('```');
+        expect(escaped.replaceAll('\u200B', '')).toBe('before```after');
+    });
+
+    it('keeps code block wrappers intact while truncating content', () => {
+        const block = formatDiscordCodeBlock('x'.repeat(100), 20);
+
+        expect(block).toHaveLength(20);
+        expect(block.startsWith('```')).toBe(true);
+        expect(block.endsWith('```')).toBe(true);
+    });
+
+    it('truncates text without splitting surrogate pairs or escape sequences', () => {
+        expect(truncateDiscordText('ab😀cd', 4)).toBe('ab…');
+        expect(truncateDiscordText('abc\\def', 5)).toBe('abc…');
+    });
+
+    it('escapes before applying the requested limit', () => {
+        const result = sanitizeDiscordText('*'.repeat(300), 256);
+
+        expect(result.length).toBeLessThanOrEqual(256);
+        expect(result.endsWith('…')).toBe(true);
+    });
+
+    it('rejects invalid maximum lengths', () => {
+        expect(() => truncateDiscordText('value', 0)).toThrow(RangeError);
+        expect(() => formatDiscordCodeBlock('value', 6)).toThrow(RangeError);
+    });
+
+    it('enforces individual and aggregate embed limits', () => {
+        const embed = new EmbedBuilder({
+            title: 't'.repeat(300),
+            description: 'd'.repeat(5_000),
+            author: { name: 'a'.repeat(300) },
+            footer: { text: 'f'.repeat(3_000) },
+            fields: Array.from({ length: 5 }, (_, index) => ({
+                name: `${index}${'n'.repeat(300)}`,
+                value: 'v'.repeat(1_500),
+            })),
+        });
+
+        enforceEmbedLimits(embed);
+        const data = embed.toJSON();
+
+        expect(data.title).toHaveLength(DISCORD_LIMITS.embed.title);
+        expect(data.description!.length).toBeLessThanOrEqual(
+            DISCORD_LIMITS.embed.description,
+        );
+        expect(data.author?.name).toHaveLength(DISCORD_LIMITS.embed.authorName);
+        expect(data.footer?.text).toHaveLength(DISCORD_LIMITS.embed.footerText);
+        expect(data.fields).toHaveLength(5);
+        expect(
+            data.fields?.every(
+                (field) =>
+                    field.name.length <= DISCORD_LIMITS.embed.fieldName &&
+                    field.value.length <= DISCORD_LIMITS.embed.fieldValue,
+            ),
+        ).toBe(true);
+        expect(countEmbedCharacters(data)).toBeLessThanOrEqual(
+            DISCORD_LIMITS.embed.total,
+        );
+    });
+});

--- a/bot/test/utils/discord.test.ts
+++ b/bot/test/utils/discord.test.ts
@@ -22,8 +22,12 @@ const countEmbedCharacters = (embed: ReturnType<EmbedBuilder['toJSON']>) =>
 
 describe('Discord text utilities', () => {
     it('escapes Discord markdown and mention syntax', () => {
-        expect(escapeDiscordMarkdown('<@123> **bold** [link](url)')).toBe(
-            '<@123\\> \\*\\*bold\\*\\* \\[link\\]\\(url\\)',
+        expect(
+            escapeDiscordMarkdown(
+                '<@123> @everyone @here **bold** [link](url)',
+            ),
+        ).toBe(
+            '<@123\\> @\u200Beveryone @\u200Bhere \\*\\*bold\\*\\* \\[link\\]\\(url\\)',
         );
     });
 
@@ -78,8 +82,8 @@ describe('Discord text utilities', () => {
         expect(data.description!.length).toBeLessThanOrEqual(
             DISCORD_LIMITS.embed.description,
         );
-        expect(data.author?.name).toHaveLength(DISCORD_LIMITS.embed.authorName);
-        expect(data.footer?.text).toHaveLength(DISCORD_LIMITS.embed.footerText);
+        expect(data.author?.name).toBe('…');
+        expect(data.footer?.text).toBe('…');
         expect(data.fields).toHaveLength(5);
         expect(
             data.fields?.every(


### PR DESCRIPTION
Disables mentions by default and sanitizes user and OpenPowerlifting text before it reaches Discord. Embed content is now kept within Discord limits. Closes #363.