### PR TITLE
chore: pin Node container images

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,11 +1,8 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 
-ARG CHAINGUARD_REGISTRY=cgr.dev/chainguard
-# TODO: pin to a specific version once Chainguard free-tier access is approved
-ARG NODE_VERSION=latest
 ARG PNPM_VERSION=11.1.2
 
-FROM ${CHAINGUARD_REGISTRY}/node:${NODE_VERSION}-dev AS pnpm
+FROM node:24.18.0-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS pnpm
 
 USER root
 ARG PNPM_VERSION
@@ -18,7 +15,7 @@ RUN --mount=type=cache,id=npm,target=/root/.npm \
     && mkdir -p /app /pnpm/store \
     && chown -R 65532:65532 /app /pnpm
 
-USER 65532
+USER 65532:65532
 
 FROM pnpm AS prod-deps
 WORKDIR /app
@@ -46,7 +43,16 @@ COPY --chown=65532:65532 bot/ ./bot/
 
 RUN pnpm --filter powercord-bot build
 
-FROM ${CHAINGUARD_REGISTRY}/node:${NODE_VERSION} AS runtime
+FROM node:24.18.0-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS runtime
+
+RUN rm -rf /opt/yarn-* \
+    /usr/local/bin/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/lib/node_modules/npm
 
 ENV NODE_ENV=production
 WORKDIR /app/bot
@@ -56,7 +62,7 @@ COPY --from=prod-deps --chown=65532:65532 /app/bot/node_modules ./node_modules
 COPY --from=prod-deps --chown=65532:65532 /app/bot/package.json ./package.json
 COPY --from=build --chown=65532:65532 /app/bot/dist ./dist
 
-USER 65532
+USER 65532:65532
 EXPOSE 3000
-ENTRYPOINT ["/usr/bin/node"]
+ENTRYPOINT ["/usr/local/bin/node"]
 CMD ["dist/index.js"]

--- a/renovate.json
+++ b/renovate.json
@@ -38,9 +38,16 @@
         },
         {
             "description": "Keep Node.js on the supported release line",
-            "matchDatasources": ["node-version"],
-            "allowedVersions": ">=24 <25",
+            "matchPackageNames": ["node"],
+            "matchDatasources": ["node-version", "docker"],
+            "allowedVersions": "/^24\\./",
             "groupName": "Node.js 24"
+        },
+        {
+            "description": "Group container image digest updates",
+            "matchManagers": ["dockerfile"],
+            "matchUpdateTypes": ["digest"],
+            "groupName": "container image digests"
         },
         {
             "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Pins the bot build and runtime to Node 24 container digests and removes unused package managers from production. Renovate will keep Node on 24 and group future container digest updates. Closes #375.