### PR TITLE
chore: align workspace configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-shamefully-hoist=true

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -65,4 +65,4 @@ COPY --from=build --chown=65532:65532 /app/bot/dist ./dist
 USER 65532:65532
 EXPOSE 3000
 ENTRYPOINT ["/usr/local/bin/node"]
-CMD ["dist/index.js"]
+CMD ["--enable-source-maps", "dist/index.js"]

--- a/bot/src/types/client.d.ts
+++ b/bot/src/types/client.d.ts
@@ -1,9 +1,0 @@
-import { SlashCommandBuilder } from '@discordjs/builders';
-import { Client, Collection } from 'discord.js';
-
-declare module 'discord.js' {
-    export interface Client {
-        commands: Collection<string, SlashCommandBuilder>;
-        execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
-    }
-}

--- a/bot/tsconfig.build.json
+++ b/bot/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
     "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "sourceMap": true
+    },
     "exclude": [
         "node_modules",
         "dist",

--- a/bot/tsconfig.json
+++ b/bot/tsconfig.json
@@ -1,23 +1,17 @@
 {
     "compilerOptions": {
-        "target": "ESNext",
+        "target": "ES2024",
         "module": "node16",
         "rootDir": "./src/",
         "outDir": "./dist/",
         "strict": true,
         "moduleResolution": "node16",
         "importHelpers": true,
-        "experimentalDecorators": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "allowSyntheticDefaultImports": true,
-        "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
-        "removeComments": true,
-        "typeRoots": ["node_modules/@types"],
-        "sourceMap": false
+        "removeComments": true
     },
-    "files": ["src/index.ts"],
-    "include": ["src/**/*", "src/types/**/*"],
+    "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "packageManager": "pnpm@11.17.0",
   "engines": {
-    "node": ">=22.0.0",
+    "node": "24.x",
     "pnpm": ">=11"
   },
   "scripts": {


### PR DESCRIPTION
Pins the workspace to Node 24 and targets ES2024 in the bot build. Stale TypeScript and pnpm settings are removed, and production stack traces now use source maps. Closes #373.